### PR TITLE
Futures do not complete on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+* Fixed issues with Android where the `Future` of the methods did not complete at all.
+* Improved error messages on Android.
+
 ## 2.0.1
 * The SDK has been adapted to receive the Flutter Plugin Version when initialized from a Flutter project.
 * Mopinion SDK updated to latest version [1.0.24](https://github.com/Mopinion-com/mopinion-sdk-android)

--- a/android/src/main/kotlin/com/mopinion/mopinion_flutter_integration_plugin/MopinionFlutterIntegrationPlugin.kt
+++ b/android/src/main/kotlin/com/mopinion/mopinion_flutter_integration_plugin/MopinionFlutterIntegrationPlugin.kt
@@ -26,103 +26,151 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.view.TextureRegistry
 
 /** MopinionFlutterIntegrationPlugin */
-class MopinionFlutterIntegrationPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, EventChannel.StreamHandler  {
+class MopinionFlutterIntegrationPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
+    EventChannel.StreamHandler {
 
-  private lateinit var channel: MethodChannel
-  private lateinit var registry: TextureRegistry
-  private lateinit var activity: Activity
-  private lateinit var mopinion: Mopinion
-  private lateinit var eventChannel: EventChannel
+    private lateinit var channel: MethodChannel
+    private lateinit var registry: TextureRegistry
+    private lateinit var activity: Activity
+    private lateinit var mopinion: Mopinion
+    private lateinit var eventChannel: EventChannel
 
-  private var eventSink: EventChannel.EventSink? = null
+    private var eventSink: EventChannel.EventSink? = null
 
-  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL)
-    channel.setMethodCallHandler(this)
-    eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, EVENT_CHANNEL_NAME)
-    eventChannel.setStreamHandler(this)
-  }
-
-  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    registry = binding.textureRegistry
-
-    channel.setMethodCallHandler(null)
-  }
-
-  override fun onMethodCall(call: MethodCall, result: Result) {
-    when(MopinionActions.map[call.method]) {
-      MopinionActions.InitialiseSDK -> {
-        val deploymentKey = call.argument(DEPLOYMENT_KEY) as String? ?: return
-        val version = call.argument(VERSION) as String? ?: return
-        val isLogActive = call.argument(LOG) as Boolean? ?: return
-        Mopinion.initialiseFromFlutter(
-          application = activity.application,
-          deploymentKey = deploymentKey,
-          pluginVersion = version,
-          log = isLogActive
-        )
-      }
-      MopinionActions.TriggerEvent -> {
-        val eventName = call.argument(FIRST_ARGUMENT) as String? ?: return
-        mopinion = Mopinion(activity as FlutterFragmentActivity, activity as FlutterFragmentActivity)
-        mopinion.event(eventName) { formState ->
-          if (formState is FormState.Loading) {
-            if (formState.isLoading) {
-              Log.d("FlutterFragmentActivity", "Loading")
-              eventSink?.success("Loading")
-            } else {
-              Log.d("FlutterFragmentActivity", "NotLoading")
-              eventSink?.success("NotLoading")
-            }
-          } else {
-            Log.d("FlutterFragmentActivity", formState::class.java.simpleName)
-            eventSink?.success(formState::class.java.simpleName)
-          }
-        }
-      }
-      MopinionActions.AddMetaData -> {
-        if (::mopinion.isInitialized) {
-          val key = call.argument(KEY) as String? ?: return
-          val value = call.argument(VALUE) as String? ?: return
-          mopinion.data(key, value)
-        }
-      }
-      MopinionActions.RemoveAllMetaData -> {
-        if (::mopinion.isInitialized) {
-          mopinion.removeData()
-        }
-      }
-      MopinionActions.RemoveMetaData -> {
-        if (::mopinion.isInitialized) {
-          val key = call.argument(KEY) as String? ?: return
-          mopinion.removeData(key)
-        }
-      }
-      null -> {}
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL)
+        channel.setMethodCallHandler(this)
+        eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, EVENT_CHANNEL_NAME)
+        eventChannel.setStreamHandler(this)
     }
-  }
 
-  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    activity = binding.activity
-  }
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        registry = binding.textureRegistry
 
-  override fun onDetachedFromActivityForConfigChanges() {
+        channel.setMethodCallHandler(null)
+    }
 
-  }
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        try {
+            when (MopinionActions.map[call.method]) {
+                MopinionActions.InitialiseSDK -> {
+                    val deploymentKey =
+                        call.argument(DEPLOYMENT_KEY) as String? ?: return result.error(
+                            "Deployment key method argument has not been provided",
+                            null,
+                            null
+                        )
+                    val version = call.argument(VERSION) as String?
+                        ?: return result.error(
+                            "Version method argument has not been provided",
+                            null,
+                            null
+                        )
+                    val isLogActive = call.argument(LOG) as Boolean?
+                        ?: return result.error(
+                            "Event name method argument has not been provided",
+                            null,
+                            null
+                        )
+                    Mopinion.initialiseFromFlutter(
+                        application = activity.application,
+                        deploymentKey = deploymentKey,
+                        pluginVersion = version,
+                        log = isLogActive
+                    )
+                    return result.success(null)
+                }
 
-  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    activity = binding.activity
-  }
+                MopinionActions.TriggerEvent -> {
+                    val eventName = call.argument(FIRST_ARGUMENT) as String?
+                        ?: return result.error("Event name has not been provided", null, null)
+                    mopinion = Mopinion(
+                        activity as FlutterFragmentActivity,
+                        activity as FlutterFragmentActivity
+                    )
+                    if (!::mopinion.isInitialized) {
+                        return result.error("Mopinion SDK is not initialized", null, null)
+                    }
+                    mopinion.event(eventName) { formState ->
+                        if (formState is FormState.Loading) {
+                            if (formState.isLoading) {
+                                Log.d("FlutterFragmentActivity", "Loading")
+                                eventSink?.success("Loading")
+                            } else {
+                                Log.d("FlutterFragmentActivity", "NotLoading")
+                                eventSink?.success("NotLoading")
+                            }
+                        } else {
+                            Log.d("FlutterFragmentActivity", formState::class.java.simpleName)
+                            eventSink?.success(formState::class.java.simpleName)
+                        }
+                    }
+                    return result.success(null)
+                }
 
-  override fun onDetachedFromActivity() {
+                MopinionActions.AddMetaData -> {
+                    if (::mopinion.isInitialized) {
+                        val key = call.argument(KEY) as String?
+                            ?: return result.error("Key has not been provided", null, null)
+                        val value = call.argument(VALUE) as String?
+                            ?: return result.error("Value has not been provided", null, null)
+                        mopinion.data(key, value)
+                        return result.success(null)
+                    } else {
+                        return result.error("Mopinion SDK is not initialized", null, null)
+                    }
+                }
 
-  }
+                MopinionActions.RemoveAllMetaData -> {
+                    if (::mopinion.isInitialized) {
+                        mopinion.removeData()
+                        result.success(null);
+                    } else {
+                        return result.error("Mopinion SDK is not initialized", null, null)
+                    }
+                }
 
-  override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-      eventSink = events
-  }
+                MopinionActions.RemoveMetaData -> {
+                    if (::mopinion.isInitialized) {
+                        val key = call.argument(KEY) as String?
+                            ?: return result.error("Key has not been provided", null, null)
+                        mopinion.removeData(key)
+                        result.success(null);
+                    } else {
+                        return result.error("Mopinion SDK is not initialized", null, null)
+                    }
+                }
 
-  override fun onCancel(arguments: Any?) {
-      eventSink = null
-  }
+                null -> {
+                    return result.error("${call.method} is not supported", null, null)
+                }
+            }
+        } catch (error: Exception) {
+            return result.error(error.toString(), null, null)
+        }
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivity() {
+
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mopinion_flutter_integration_plugin
 description: Plugin to integrate Mopinion Native Mobile SDKs into Flutter projects.
-version: 2.0.1
+version: 2.1.0
 homepage: https://mopinion.com/mobile-sdk-downloads/
 
 environment:


### PR DESCRIPTION
After implementing the package inside our applications, we discovered an issue with Android. The `Future` object did not complete on all methods. This causes infinite awaiting. The reason for that was in the native code, the `Result` object was never returned. This is needed because after sending a platform message, Flutter awaits a result from the native platform. This was correctly implemented for iOS but not for Android. I also improved the error handling a bit with meaningful messages. Please take a look @ManuelCrovetto.