### PR TITLE
Mopinion Android SDK dependency updated to v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+* Mopinion Android SDK updated to latest version [2.0.2](https://github.com/Mopinion-com/mopinion-sdk-android)
+
 ## 3.0.0
 * Mopinion Android SDK updated to latest version [2.0.0](https://github.com/Mopinion-com/mopinion-sdk-android)
 * Using UIViewController instead of FlutterViewController for iOS.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,5 +70,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.Mopinion-com.native-android-sdk:mopinion-sdk:2.0.0'
+    implementation 'com.github.Mopinion-com.native-android-sdk:mopinion-sdk:2.0.2'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mopinion_flutter_integration_plugin
 description: Plugin to integrate Mopinion Native Mobile SDKs into Flutter projects.
-version: 3.0.0
+version: 3.0.1
 homepage: https://mopinion.com/mobile-sdk-downloads/
 
 environment:


### PR DESCRIPTION
## Purpose

- Address the issue https://github.com/Mopinion-com/mopinion_flutter_integration_plugin/issues/31

- Includes Mopinion Android SDK v2.0.2.

## What's changed in the Android SDK
- Room issues has been fixed -> https://github.com/Mopinion-com/mopinion-sdk-android/issues/6.
- Android Photo Picker is implemented, avoiding the READ_MEDIA_IMAGES permission use -> https://github.com/Mopinion-com/mopinion-sdk-android/issues/5.
- Patch for duplicated or ambiguous style naming -> https://github.com/Mopinion-com/mopinion-sdk-android/issues/4.
- Screenshot uploading has been improved.
- Gets the Android platform version with the Android Version and not with the API level anymore.

